### PR TITLE
Pass line height variable as an argument into mixin include.

### DIFF
--- a/_base.headings.scss
+++ b/_base.headings.scss
@@ -14,26 +14,30 @@ $inuit-heading-size-4:  20px !default;
 $inuit-heading-size-5:  16px !default;
 $inuit-heading-size-6:  14px !default;
 
+// If you do not want inuitcss to automatically generate line-heights
+// (vertical rhythm) assign your value to this variable in `style.scss`.
+$inuit-heading-line-height: 'auto' !default;
+
 h1 {
-    @include inuit-font-size($inuit-heading-size-1);
+    @include inuit-font-size($inuit-heading-size-1, $inuit-heading-line-height);
 }
 
 h2 {
-    @include inuit-font-size($inuit-heading-size-2);
+    @include inuit-font-size($inuit-heading-size-2, $inuit-heading-line-height);
 }
 
 h3 {
-    @include inuit-font-size($inuit-heading-size-3);
+    @include inuit-font-size($inuit-heading-size-3, $inuit-heading-line-height);
 }
 
 h4 {
-    @include inuit-font-size($inuit-heading-size-4);
+    @include inuit-font-size($inuit-heading-size-4, $inuit-heading-line-height);
 }
 
 h5 {
-    @include inuit-font-size($inuit-heading-size-5);
+    @include inuit-font-size($inuit-heading-size-5, $inuit-heading-line-height);
 }
 
 h6 {
-    @include inuit-font-size($inuit-heading-size-6);
+    @include inuit-font-size($inuit-heading-size-6, $inuit-heading-line-height);
 }


### PR DESCRIPTION
This allows us to override the line height on the headings.

Leading on headings with multi line wraps is too generous when preserving the vertical rhythm. Ideally you’d override the auto generated line-height with a value more considered to your typeface (low x-height) and scale.

The default behaviour is preserved by using an `auto` value.
